### PR TITLE
Exposes the Expires attribute on Android to flutter apps, aligning with iOS.

### DIFF
--- a/android/src/main/java/io/flutter/plugins/webview_cookie_manager/WebviewCookieManagerPlugin.java
+++ b/android/src/main/java/io/flutter/plugins/webview_cookie_manager/WebviewCookieManagerPlugin.java
@@ -142,6 +142,13 @@ public class WebviewCookieManagerPlugin implements FlutterPlugin, MethodCallHand
         resultMap.put("path", cookie.getPath());
         resultMap.put("domain", cookie.getDomain());
         resultMap.put("secure", cookie.getSecure());
+
+        if (!cookie.hasExpired() && !cookie.getDiscard() && cookie.getMaxAge() > 0) {
+            // translate `max-age` to `expires` by computing future expiration date
+            long expires = (System.currentTimeMillis() / 1000) + cookie.getMaxAge();
+            resultMap.put("expires", expires);
+        }
+        
         if (Build.VERSION.SDK_INT >= VERSION_CODES.N) {
             resultMap.put("httpOnly", cookie.isHttpOnly());
         }

--- a/ios/Classes/SwiftWebviewCookieManagerPlugin.swift
+++ b/ios/Classes/SwiftWebviewCookieManagerPlugin.swift
@@ -127,7 +127,7 @@ public class SwiftWebviewCookieManagerPlugin: NSObject, FlutterPlugin {
                 cookieList.add(_cookieToDictionary(cookie: cookie))
             }
             result(cookieList)
-        }                              
+        }
     }
     
     public static func _cookieToDictionary(cookie: HTTPCookie) -> NSDictionary {


### PR DESCRIPTION
Exposes the `Expires` attribute on Android to flutter apps, aligning with iOS. 

The HttpCookie class in Android (java.net sdk) has awkward `Expires` handling. It translates `Expires` into `Max-Age` by first converting it into a seconds offset from the current system time as described here: https://www.mit.edu/afs.new/sipb/project/android/docs/reference/java/net/HttpCookie.html. And as a consequence `Expires` is not available from an accessor, it must be calculated from the `Max-Age` attribute by performing the reverse translation. This patch performs that translation to ensure we carry over the remaining the duration between cookie gets and sets, aswell as to align with iOS which does expose `Expires`.

It should be noted that `Expires` is a deprecated attributed, in favor of the newer `Max-Age` attribute. However due to the nature of how this is handled on Android, namely that max-age is not readjusted and thus cannot be used reliably between getting and setting of cookies, we should use `Expires` to ensure cookies expire properly.

