### PR TITLE
Custom Cookie

### DIFF
--- a/android/src/main/java/io/flutter/plugins/webview_cookie_manager/WebviewCookieManagerPlugin.java
+++ b/android/src/main/java/io/flutter/plugins/webview_cookie_manager/WebviewCookieManagerPlugin.java
@@ -142,6 +142,13 @@ public class WebviewCookieManagerPlugin implements FlutterPlugin, MethodCallHand
         resultMap.put("path", cookie.getPath());
         resultMap.put("domain", cookie.getDomain());
         resultMap.put("secure", cookie.getSecure());
+
+        if (!cookie.hasExpired() && !cookie.getDiscard() && cookie.getMaxAge() > 0) {
+            // translate `max-age` to `expires` by computing future expiration date
+            long expires = (System.currentTimeMillis() / 1000) + cookie.getMaxAge();
+            resultMap.put("expires", expires);
+        }
+        
         if (Build.VERSION.SDK_INT >= VERSION_CODES.N) {
             resultMap.put("httpOnly", cookie.isHttpOnly());
         }

--- a/android/src/main/java/io/flutter/plugins/webview_cookie_manager/WebviewCookieManagerPlugin.java
+++ b/android/src/main/java/io/flutter/plugins/webview_cookie_manager/WebviewCookieManagerPlugin.java
@@ -142,13 +142,6 @@ public class WebviewCookieManagerPlugin implements FlutterPlugin, MethodCallHand
         resultMap.put("path", cookie.getPath());
         resultMap.put("domain", cookie.getDomain());
         resultMap.put("secure", cookie.getSecure());
-
-        if (!cookie.hasExpired() && !cookie.getDiscard() && cookie.getMaxAge() > 0) {
-            // translate `max-age` to `expires` by computing future expiration date
-            long expires = (System.currentTimeMillis() / 1000) + cookie.getMaxAge();
-            resultMap.put("expires", expires);
-        }
-        
         if (Build.VERSION.SDK_INT >= VERSION_CODES.N) {
             resultMap.put("httpOnly", cookie.isHttpOnly());
         }

--- a/ios/Classes/SwiftWebviewCookieManagerPlugin.swift
+++ b/ios/Classes/SwiftWebviewCookieManagerPlugin.swift
@@ -5,62 +5,75 @@ import WebKit
 @available(iOS 11.0, *)
 public class SwiftWebviewCookieManagerPlugin: NSObject, FlutterPlugin {
     static var httpCookieStore: WKHTTPCookieStore?
-    
-  public static func register(with registrar: FlutterPluginRegistrar) {
-    httpCookieStore = WKWebsiteDataStore.default().httpCookieStore
-    
-    let channel = FlutterMethodChannel(name: "webview_cookie_manager", binaryMessenger: registrar.messenger())
-    let instance = SwiftWebviewCookieManagerPlugin()
-    registrar.addMethodCallDelegate(instance, channel: channel)
-  }
 
-  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    switch call.method {
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        httpCookieStore = WKWebsiteDataStore.default().httpCookieStore
+
+        let channel = FlutterMethodChannel(name: "webview_cookie_manager", binaryMessenger: registrar.messenger())
+        let instance = SwiftWebviewCookieManagerPlugin()
+        registrar.addMethodCallDelegate(instance, channel: channel)
+    }
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
         case "getCookies":
             let arguments = call.arguments as! NSDictionary
             let url = arguments["url"] as? String
             SwiftWebviewCookieManagerPlugin.getCookies(urlString: url, result: result)
-            break
         case "setCookies":
-            let cookies = call.arguments as! Array<NSDictionary>
+            let cookies = call.arguments as! [NSDictionary]
             SwiftWebviewCookieManagerPlugin.setCookies(cookies: cookies, result: result)
-            break
         case "hasCookies":
             SwiftWebviewCookieManagerPlugin.hasCookies(result: result)
-            break
         case "clearCookies":
             SwiftWebviewCookieManagerPlugin.clearCookies(result: result)
-            break
         default:
             result(FlutterMethodNotImplemented)
-            break
-    }
-  }
-    
-    public static func setCookies(cookies: Array<NSDictionary>, result: @escaping FlutterResult) {
-        for cookie in cookies {
-            _setCookie(cookie: cookie, result: result)
         }
     }
-    
-    public static func clearCookies(result: @escaping FlutterResult) {
 
-        httpCookieStore!.getAllCookies { (cookies) in
+    public static func setCookies(cookies: [NSDictionary], result: @escaping FlutterResult) {
+        // sets the cookie at the index in the cookies list
+        func setCookieAt(index: Int = 0) {
+            if index >= cookies.count {
+                result(true)
+                return
+            }
+            // set the cookie, and on completion set the next cookie
+            _setCookie(cookie: cookies[index], done: { () in
+                setCookieAt(index: index + 1)
+            })
+        }
+
+        setCookieAt()
+    }
+
+    public static func clearCookies(result: @escaping FlutterResult) {
+        // delete HTTPCookieStorage all cookies
+        if let cookies = HTTPCookieStorage.shared.cookies {
             for cookie in cookies {
-                httpCookieStore!.delete(cookie, completionHandler: nil)
+                HTTPCookieStorage.shared.deleteCookie(cookie)
             }
-            // delete HTTPCookieStorage all cookies
-            if let cookies = HTTPCookieStorage.shared.cookies {
-                for cookie in cookies {
-                    HTTPCookieStorage.shared.deleteCookie(cookie)
+        }
+
+        httpCookieStore!.getAllCookies { cookies in
+            // sets the cookie at the index in the cookies list
+            func deleteCookieAt(index: Int = 0) {
+                if index >= cookies.count {
+                    result(nil)
+                    return
                 }
+                httpCookieStore!.delete(cookies[index], completionHandler: { () in
+                    deleteCookieAt(index: index + 1)
+                })                
             }
-            result(nil)
+
+            deleteCookieAt()            
         }
     }
-    
+
     public static func hasCookies(result: @escaping FlutterResult) {
-        httpCookieStore!.getAllCookies { (cookies) in
+        httpCookieStore!.getAllCookies { cookies in
             var isEmpty = cookies.isEmpty
             if isEmpty {
                 // If it is empty, check whether the HTTPCookieStorage cookie is also empty.
@@ -69,12 +82,12 @@ public class SwiftWebviewCookieManagerPlugin: NSObject, FlutterPlugin {
             result(!isEmpty)
         }
     }
-    
-    private static func _setCookie(cookie: NSDictionary, result: @escaping FlutterResult) {
+
+    private static func _setCookie(cookie: NSDictionary, done: @escaping () -> Void) {
         let expiresDate = cookie["expires"] as? Double
         let isSecure = cookie["secure"] as? Bool
         let isHttpOnly = cookie["httpOnly"] as? Bool
-        
+
         var properties: [HTTPCookiePropertyKey: Any] = [:]
         properties[.name] = cookie["name"] as! String
         properties[.value] = cookie["value"] as! String
@@ -83,68 +96,68 @@ public class SwiftWebviewCookieManagerPlugin: NSObject, FlutterPlugin {
         if expiresDate != nil {
             properties[.expires] = Date(timeIntervalSince1970: expiresDate!)
         }
-        if isSecure != nil && isSecure! {
+        if isSecure != nil, isSecure! {
             properties[.secure] = "TRUE"
         }
-        if isHttpOnly != nil && isHttpOnly! {
+        if isHttpOnly != nil, isHttpOnly! {
             properties[.init("HttpOnly")] = "YES"
         }
-        
+
         let cookie = HTTPCookie(properties: properties)!
-        
-        httpCookieStore!.setCookie(cookie, completionHandler: {() in
-            result(true)
+
+        httpCookieStore!.setCookie(cookie, completionHandler: { () in
+            done()
         })
     }
-    
+
     public static func getCookies(urlString: String?, result: @escaping FlutterResult) {
         // map empty string and nil to "", indicating that no filter should be applied
-        let url = urlString.map{ $0.trimmingCharacters(in: .whitespacesAndNewlines) } ?? ""
+        let url = urlString.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } ?? ""
 
         // ensure passed in url is parseable, and extract the host
-        let host = URL(string: url)?.host           
-       
+        let host = URL(string: url)?.host
+
         // fetch and filter cookies from WKHTTPCookieStore
-        httpCookieStore!.getAllCookies { (wkCookies) in
-                    
+        httpCookieStore!.getAllCookies { wkCookies in
+
             func matches(cookie: HTTPCookie) -> Bool {
                 // nil host means unparseable url or empty string
-                let containsHost = host.map{cookie.domain.contains($0)} ?? false
+                let containsHost = host.map { cookie.domain.contains($0) } ?? false
                 return url == "" || containsHost
             }
-                                        
-            var cookies = wkCookies.filter{ matches(cookie: $0) }
-    
+
+            var cookies = wkCookies.filter { matches(cookie: $0) }
+
             // If the cookie value is empty in WKHTTPCookieStore,
             // get the cookie value from HTTPCookieStorage
             if cookies.count == 0 {
                 if let httpCookies = HTTPCookieStorage.shared.cookies {
-                    cookies = httpCookies.filter{ matches(cookie: $0) }
+                    cookies = httpCookies.filter { matches(cookie: $0) }
                 }
-            } 
-            let cookieList: NSMutableArray = NSMutableArray()
-            cookies.forEach{ cookie in 
+            }
+            let cookieList = NSMutableArray()
+            cookies.forEach { cookie in
                 cookieList.add(_cookieToDictionary(cookie: cookie))
             }
             result(cookieList)
         }
     }
-    
+
     public static func _cookieToDictionary(cookie: HTTPCookie) -> NSDictionary {
-        let result : NSMutableDictionary =  NSMutableDictionary()
-        
+        let result = NSMutableDictionary()
+
         result.setValue(cookie.name, forKey: "name")
         result.setValue(cookie.value, forKey: "value")
         result.setValue(cookie.domain, forKey: "domain")
         result.setValue(cookie.path, forKey: "path")
         result.setValue(cookie.isSecure, forKey: "secure")
         result.setValue(cookie.isHTTPOnly, forKey: "httpOnly")
-        
+
         if cookie.expiresDate != nil {
             let expiredDate = cookie.expiresDate?.timeIntervalSince1970
             result.setValue(Int(expiredDate!), forKey: "expires")
         }
-        
-        return result;
+
+        return result
     }
 }

--- a/ios/Classes/SwiftWebviewCookieManagerPlugin.swift
+++ b/ios/Classes/SwiftWebviewCookieManagerPlugin.swift
@@ -65,10 +65,10 @@ public class SwiftWebviewCookieManagerPlugin: NSObject, FlutterPlugin {
                 }
                 httpCookieStore!.delete(cookies[index], completionHandler: { () in
                     deleteCookieAt(index: index + 1)
-                })                
+                })
             }
 
-            deleteCookieAt()            
+            deleteCookieAt()
         }
     }
 

--- a/ios/Classes/SwiftWebviewCookieManagerPlugin.swift
+++ b/ios/Classes/SwiftWebviewCookieManagerPlugin.swift
@@ -127,7 +127,7 @@ public class SwiftWebviewCookieManagerPlugin: NSObject, FlutterPlugin {
                 cookieList.add(_cookieToDictionary(cookie: cookie))
             }
             result(cookieList)
-        }                              
+        }
     }
     
     public static func _cookieToDictionary(cookie: HTTPCookie) -> NSDictionary {

--- a/lib/cookie.dart
+++ b/lib/cookie.dart
@@ -1,0 +1,67 @@
+import 'dart:io';
+
+class Cookie {
+  final String name;
+  final String value;
+
+  String path;
+  String domain;
+  bool secure;
+  bool httpOnly;
+
+  DateTime expires;
+  int maxAge;
+
+  Cookie(this.name, this.value);
+
+  String toString() {
+    StringBuffer sb = new StringBuffer();
+    sb..write(name)..write("=")..write(value);
+    var expires = this.expires;
+    if (expires != null) {
+      sb..write("; Expires=")..write(HttpDate.format(expires));
+    }
+    if (maxAge != null) {
+      sb..write("; Max-Age=")..write(maxAge);
+    }
+    if (domain != null) {
+      sb..write("; Domain=")..write(domain);
+    }
+    if (path != null) {
+      sb..write("; Path=")..write(path);
+    }
+
+    if (secure != null) sb.write("; Secure");
+    if (httpOnly != null) sb.write("; HttpOnly");
+
+    return sb.toString();
+  }
+
+  Cookie.fromJson(Map<String, dynamic> json)
+      : name = json['name'],
+        value = json['value'],
+        expires = json['expires'] != null
+            ? DateTime.fromMillisecondsSinceEpoch(json['expires'])
+            : null,
+        maxAge = json['maxAge'] != null ? json['maxAge'] : null,
+        path = json['path'] != null ? json['path'] : null,
+        domain = json['domain'] != null ? json['domain'] : null,
+        secure = json['secure'] != null ? json['secure'] : null,
+        httpOnly = json['httpOnly'] != null ? json['httpOnly'] : null;
+
+  Map<String, dynamic> toJson() {
+    Map<String, dynamic> map = {
+      'name': name,
+      'value': value,
+    };
+
+    if (expires != null) map['expires'] = expires.millisecondsSinceEpoch;
+    if (maxAge != null) map['maxAge'] = maxAge;
+    if (path != null) map['path'] = path;
+    if (domain != null) map['domain'] = domain;
+    if (secure != null) map['secure'] = secure;
+    if (httpOnly != null) map['httpOnly'] = httpOnly;
+
+    return map;
+  }
+}

--- a/lib/webview_cookie_manager.dart
+++ b/lib/webview_cookie_manager.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'dart:io';
-
 import 'package:flutter/services.dart';
+import 'package:webview_cookie_manager/cookie.dart';
+export 'package:webview_cookie_manager/cookie.dart';
 
 class WebviewCookieManager {
   static const _channel = MethodChannel('webview_cookie_manager');
@@ -33,6 +33,7 @@ class WebviewCookieManager {
                 ..path = result['path']
                 ..domain = result['domain']
                 ..secure = result['secure']
+                ..maxAge = result['maxAge']
                 ..httpOnly = result['httpOnly'];
 
           if (result['expires'] != null) {
@@ -70,6 +71,7 @@ class WebviewCookieManager {
         'domain': c.domain,
         'secure': c.secure,
         'httpOnly': c.httpOnly,
+        'maxAge': c.maxAge,
         'asString': c.toString(),
       };
 


### PR DESCRIPTION
Implements a custom dart cookie implementation to supersede the existing one from `dart:io` package. The reasons for this are to due with RFC compliance, performance and flexibility. 
- The dart:io implementation is overly strict on the cookie names it accepts, namely it errors out if certain characters are included in the name: 
https://github.com/dart-lang/sdk/blob/d63d5d93a59b370bf5f5c277109110cb67a96b75/sdk/lib/_http/http.dart#L989-L995
 This restriction is not enforced by web browsers, for example you can include the `@` symbol in a cookie name without error. 
- The `dart:io`  implementation performs unnecessary validation and parsing. Since cookies originate direcrtly from webview cookie managers, validation is completely unnecessary and wasteful.
- The `dart:io` implementation does not have support for JSON serialization.



This patch additionally makes updates to the existing setCookies and clearCookies functions. Namely, the functions completely finish their operations (setting or clearing) before returning an result asynchronously. Prior to this patch, the functions returned immediately, without waiting for completion leading to race conditions.