### PR TITLE
Ignore invalid cookies when getting cookies

### DIFF
--- a/lib/webview_cookie_manager.dart
+++ b/lib/webview_cookie_manager.dart
@@ -27,22 +27,29 @@ class WebviewCookieManager {
     return _channel.invokeListMethod<Map>('getCookies', {'url': url}).then(
         (results) => results == null
             ? <Cookie>[]
-            : results.map((Map result) {
-                final c = Cookie(result['name'] ?? '',
-                    removeInvalidCharacter(result['value'] ?? ''))
-                  // following values optionally work on iOS only
-                  ..path = result['path']
-                  ..domain = result['domain']
-                  ..secure = result['secure'] ?? false
-                  ..httpOnly = result['httpOnly'] ?? true;
+            : results
+                .map((Map result) {
+                  Cookie? c;
+                  try {
+                    c = Cookie(result['name'] ?? '',
+                        removeInvalidCharacter(result['value'] ?? ''))
+                      // following values optionally work on iOS only
+                      ..path = result['path']
+                      ..domain = result['domain']
+                      ..secure = result['secure'] ?? false
+                      ..httpOnly = result['httpOnly'] ?? true;
 
-                if (result['expires'] != null) {
-                  c.expires = DateTime.fromMillisecondsSinceEpoch(
-                      (result['expires'] * 1000).toInt());
-                }
-
-                return c;
-              }).toList());
+                    if (result['expires'] != null) {
+                      c.expires = DateTime.fromMillisecondsSinceEpoch(
+                          (result['expires'] * 1000).toInt());
+                    }
+                  } on FormatException catch (_) {
+                    c = null;
+                  }
+                  return c;
+                })
+                .whereType<Cookie>()
+                .toList());
   }
 
   /// Remove cookies with [currentUrl] for IOS and Android

--- a/test/webview_cookie_manager_test.dart
+++ b/test/webview_cookie_manager_test.dart
@@ -1,18 +1,50 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:webview_cookie_manager/webview_cookie_manager.dart';
 
 void main() {
   const MethodChannel channel = MethodChannel('webview_cookie_manager');
 
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  List<Map<String, String>> cookies = [
+    {
+      "name": "valid_cookie",
+      "value": "1111-2222-3333-4444",
+      "path": "/",
+      "domain": "http://www.test.com",
+    },
+    {
+      "name": "invalid_cookie",
+      "value": "1111,2222,3333,4444",
+      "path": "/",
+      "domain": "http://www.test.com",
+    },
+    {
+      "name": "another_valid_cookie",
+      "value": "1111222233334444",
+      "path": "/",
+      "domain": "http://www.test.com",
+    },
+  ];
+
   setUp(() {
     channel.setMockMethodCallHandler((MethodCall methodCall) async {
-      return '42';
+      return cookies;
     });
   });
 
   tearDown(() {
     channel.setMockMethodCallHandler(null);
+  });
+
+  test('The invalid cookie is ignored', () async {
+    final cookieManager = WebviewCookieManager();
+
+    final cookies = await cookieManager.getCookies('http://www.test.com');
+
+    expect(cookies.length, 2);
+    expect(cookies.first.name, "valid_cookie");
+    expect(cookies.last.name, "another_valid_cookie");
   });
 }


### PR DESCRIPTION
When calling getCookies(), all cookies for the provided url are serialised.
There is a possibility that a cookie's value could contain invalid
characters. If this is the case, a FormatException is thrown during
the creation of the Cookie object, resulting in no cookies being
serialised. This is particularly annoying if the desired result of
calling getCookies() is to fetch information about a particular
cookie.

This commit handles serialisation of cookies with invalid values
by catching any cookies with invalid values and removing them from
the returned list of cookies.