### PR TITLE
bugfix: Build error with Flutter 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.5
+
+* bugfix: Build error with Flutter 2.5.1([#47](https://github.com/fryette/webview_cookie_manager/issues/53))
+
 ## 2.0.4
 
 * bugfix: Fixed bug where iOS would never return future if cookie list is empty([#47](https://github.com/fryette/webview_cookie_manager/issues/47))

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,7 @@ android {
 
 dependencies {
     // flutter plugin intellisense
-    compileOnly "io.flutter:flutter_embedding_debug:1.0.0-d1bc06f032f9d6c148ea6b96b48261d6f545004f"
+    compileOnly "io.flutter:flutter_embedding_debug:1.0.0-b3af521a050e6ef076778bcaf16e27b2521df8f8"
 
     testImplementation 'junit:junit:4.13.1'
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -35,7 +35,7 @@ android {
     defaultConfig {
         applicationId "com.example.webview_cookie_manager_example"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -13,7 +13,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  webview_flutter: ^2.0.0-nullsafety.4
+  webview_flutter: ^2.0.14
 
   webview_cookie_manager:
     # When depending on this package from a real application you should use:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_cookie_manager
 description: Have you been turned into a cookie management problem? This package can help. It has all of the cookie management functionality you have been looking for.
-version: 2.0.4
+version: 2.0.5
 repository: https://github.com/fryette/webview_cookie_manager
 homepage: https://github.com/fryette/webview_cookie_manager
 issue_tracker: https://github.com/fryette/webview_cookie_manager/issues


### PR DESCRIPTION
## 2.0.5

* bugfix: Build error with Flutter 2.5.1([#47](https://github.com/fryette/webview_cookie_manager/issues/53))

Added a fix to the build issue presented in flutter 2.5.1.

Also not sure if you want the version to be 2.1.0 or 2.0.5