### PR TITLE
Remove engine dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,8 +34,5 @@ android {
 }
 
 dependencies {
-    // flutter plugin intellisense
-    compileOnly "io.flutter:flutter_embedding_debug:1.0.0-b3af521a050e6ef076778bcaf16e27b2521df8f8"
-
     testImplementation 'junit:junit:4.13.1'
 }


### PR DESCRIPTION
~~I've inserted flutter_embedding_debug dependency for android studio intellisense, but it looks like it can break build with new engine versions. So I replaced it with no version specified one, and specified version only when opening this project directly with android studio.~~

Intellisense has no problem by opening example/android directory. So remove redundant dependency.