### PR TITLE
Fix library for the newer AGP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.7
+
+* Add missing namespace parameter 
+
 ## 2.0.6
 
 * Remove engine dependency([#55](https://github.com/fryette/webview_cookie_manager/pull/55))

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 28
 
+    namespace "io.flutter.plugins.webview_cookie_manager"
+
     defaultConfig {
         minSdkVersion 16
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: webview_cookie_manager
 description: Have you been turned into a cookie management problem? This package can help. It has all of the cookie management functionality you have been looking for.
-version: 2.0.6
+version: 2.0.7
 repository: https://github.com/fryette/webview_cookie_manager
 homepage: https://github.com/fryette/webview_cookie_manager
 issue_tracker: https://github.com/fryette/webview_cookie_manager/issues


### PR DESCRIPTION
Newer versions of the Android Gradle Plugin requires namespace parameter 